### PR TITLE
Packaging enhancements for AIX and Solaris.

### DIFF
--- a/AIX/certnanny.pre-deinstall.sh
+++ b/AIX/certnanny.pre-deinstall.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/ksh
-
-/usr/bin/rm /usr/bin/certnanny
-

--- a/AIX/certnanny.unconfiguration.sh
+++ b/AIX/certnanny.unconfiguration.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/ksh
+
+/usr/bin/rm -f /usr/bin/certnanny
+

--- a/AIX/lpp_template.in
+++ b/AIX/lpp_template.in
@@ -11,12 +11,11 @@ Fileset
   Requisites: *coreq CertNanny.sscep 0.5.0.0
   USRLIBLPPFiles
     Post-installation Script: __PACKAGINGDIR__/AIX/certnanny.post-install.sh
-    Pre-deinstall Script: __PACKAGINGDIR__/AIX/certnanny.pre-deinstall.sh
+    Unconfiguration Script: __PACKAGINGDIR__/AIX/certnanny.unconfiguration.sh
   EOUSRLIBLPPFiles
   USRFiles
     /opt/CertNanny
     /opt/CertNanny/bin
-    /opt/CertNanny/lib
     /opt/CertNanny/FAQ
     /opt/CertNanny/LICENSE.CertNanny
     /opt/CertNanny/QUICKSTART

--- a/AIX/override_inventory
+++ b/AIX/override_inventory
@@ -16,15 +16,6 @@
 	size =
 	checksum =
 
-/opt/CertNanny/lib:
-	owner = root
-	group = system
-	mode = 755
-	type =
-	class =
-	size =
-	checksum =
-
 /opt/CertNanny/FAQ:
 	owner = root
 	group = system

--- a/Solaris/Prototype
+++ b/Solaris/Prototype
@@ -5,7 +5,7 @@ d none /opt/CertNanny/bin 0755 root root
 f none /opt/CertNanny/COPYRIGHT.CertNanny 0644 root root
 f none /opt/CertNanny/QUICKSTART 0644 root root
 f none /opt/CertNanny/bin/certnanny 0755 root root
-s none /usr/bin/certnanny=/opt/CertNanny/bin/certnanny
+#s none /usr/bin/certnanny=/opt/CertNanny/bin/certnanny
 d none /opt/CertNanny/lib 0755 root root
 d none /opt/CertNanny/lib/java 0755 root root
 f none /opt/CertNanny/lib/java/ExtractKey.jar 0644 root root


### PR DESCRIPTION
- AIX: Changed the pre-deinstall script to unconfigure
     to address an issue where failed deinstallations
     caused follow-on problems
- Solaris: Removed symlink from /usr/bin to allow installations
         into local zones
