### PR TITLE
Minor AIX packaging enhancements.

### DIFF
--- a/AIX/lpp_template.in
+++ b/AIX/lpp_template.in
@@ -65,6 +65,6 @@ Fileset
   ROOT Part: N
   ROOTFiles
   EOROOTFiles
-  OVERRIDE_INVENTORY: /tmp/override_inventory
+  OVERRIDE_INVENTORY: __PACKAGINGDIR__/AIX/override_inventory
 EOFileset
 

--- a/AIX/make_AIX_package.sh
+++ b/AIX/make_AIX_package.sh
@@ -23,9 +23,14 @@ tar cf - lib | (cd opt/CertNanny; tar xf -)
 # compute the version number (VRML)
 version=$(head -n 1 VERSION)
 version="$version.0"
-# provide the override inventory file to file ownership and permissions
-cp AIX/override_inventory /tmp
 # create the template and building the package
 sed "s/VERSIONINFO/$version/" < AIX/lpp_template.in | sed "s#__PACKAGINGDIR__#$PWD#" > AIX/lpp_template
-mkinstallp -d . -T AIX/lpp_template
+# make sure we can execute mkinstallp ... if not, try sudo
+if [ -x /usr/sbin/mkinstallp ]
+then
+  mkinstallp=/usr/sbin/mkinstallp
+else
+  mkinstallp="sudo /usr/sbin/mkinstallp"
+fi
+$mkinstallp -d . -T AIX/lpp_template
 


### PR DESCRIPTION
- Try sudo if /usr/sbin/mkinstallp is not executable directly
  (packaging as a non-root user)
- Removed unnecessary copying of override inventory
