### PR TITLE
Fix for gsk 7

### DIFF
--- a/lib/perl/CertNanny/Keystore/MQ.pm
+++ b/lib/perl/CertNanny/Keystore/MQ.pm
@@ -1456,7 +1456,7 @@ sub _getCertLabel {
   foreach my $entry (@certList) {
    chomp $entry;
    # some gskit versions prefix the label with a dash and whitespace
-   $entry =~ s{ \A - \s* }{}xms;
+   $entry =~ s{ \A [\-!] \s* }{}xms;
    if ($entry =~ m/$match/) { 
     $label = $entry;
     CertNanny::Logging->debug("found label '$label'");


### PR DESCRIPTION
gsk7capicmd of gsk 7,  behaves differnt to gsk 7.1
private key indicators now supported are "-" or "!"
