### PR TITLE
Update Config.pm

### DIFF
--- a/lib/perl/CertNanny/Config.pm
+++ b/lib/perl/CertNanny/Config.pm
@@ -506,7 +506,7 @@ sub _sha1_hex {
   my $sha;
   my $openssl = $self->get('cmd.openssl', 'FILE');
   if (defined($openssl)) {
-    my @cmd = (qq("$openssl"), 'dgst', '-sha', qq("$file"));
+    my @cmd = (qq("$openssl"), 'dgst', '-sha1', qq("$file"));
     chomp($sha = CertNanny::Util->runCommand(\@cmd, WANTOUT => 1));
     if ($sha =~ /^.*\)= (.*)$/) {
       $sha = $1;


### PR DESCRIPTION
SHA1 Option -sha in OpenSSL 1.1.1 no longer available. Use -sha1 instead.

{code}
> openssl version
OpenSSL 1.1.1g FIPS  21 Apr 2020

> openssl dgst -list
Supported digests:
-blake2b512                -blake2s256                -md4
-md5                       -md5-sha1                  -ripemd
-ripemd160                 -rmd160                    -sha1
-sha224                    -sha256                    -sha3-224
-sha3-256                  -sha3-384                  -sha3-512
-sha384                    -sha512                    -sha512-224
-sha512-256                -shake128                  -shake256
-sm3                       -ssl3-md5                  -ssl3-sha1
-whirlpool
{code}